### PR TITLE
Fix overlay method for asset viewport

### DIFF
--- a/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.cpp
+++ b/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.cpp
@@ -29,7 +29,10 @@ void SCharacter2DAssetViewport::Construct(const FArguments& InArgs)
 
     SEditorViewport::Construct(SEditorViewport::FArguments());
 
-    AddOverlayWidget(BuildCameraToolbar());
+    if (EditorViewportClient.IsValid())
+    {
+        EditorViewportClient->AddViewportWidgetContent(BuildCameraToolbar());
+    }
 
 	if (Asset && PreviewScene->GetWorld())
 	{


### PR DESCRIPTION
## Summary
- replace deprecated `AddOverlayWidget` call with `AddViewportWidgetContent`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684300a2ce788326a4e324e245e9a9b2