### PR TITLE
Fix SOverlay include and toolbar return type

### DIFF
--- a/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.cpp
+++ b/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.cpp
@@ -7,7 +7,7 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Layout/SBox.h"
-#include "Widgets/Layout/SOverlay.h"
+#include "Widgets/SOverlay.h"
 
 void SCharacter2DAssetViewport::OnFloatingButtonClicked()
 {
@@ -72,7 +72,7 @@ TSharedRef<FEditorViewportClient> SCharacter2DAssetViewport::MakeEditorViewportC
         return EditorViewportClient.ToSharedRef();
 }
 
-TSharedRef<SWidget> SCharacter2DAssetViewport::MakeViewportToolbar()
+TSharedPtr<SWidget> SCharacter2DAssetViewport::MakeViewportToolbar()
 {
     return BuildCameraToolbar();
 }

--- a/Plugins/Character2D/Source/Character2DEditor/Public/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.h
+++ b/Plugins/Character2D/Source/Character2DEditor/Public/Character2DAssetEditorToolkit/SCharacter2DAssetViewport.h
@@ -4,7 +4,7 @@
 #include "SEditorViewport.h"
 #include "Character2DAsset.h"
 #include "SCommonEditorViewportToolbarBase.h"
-#include "Widgets/Layout/SOverlay.h"
+#include "Widgets/SOverlay.h"
 
 class FPreviewScene;
 class ACharacter2DActor;
@@ -39,7 +39,7 @@ protected:
         virtual TSharedRef<FEditorViewportClient> MakeEditorViewportClient() override;
 
         // Override to add toolbar and overlays
-        virtual TSharedRef<SWidget> MakeViewportToolbar() override;
+        virtual TSharedPtr<SWidget> MakeViewportToolbar() override;
         virtual void PopulateViewportOverlays(TSharedRef<SOverlay> Overlay) override;
 
        virtual void OnFloatingButtonClicked() override;


### PR DESCRIPTION
## Summary
- correct SOverlay include path
- fix `MakeViewportToolbar` override signature to match UE 5.5

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684306962294832680a1943f81be5a2f