### PR TITLE
Update head hierarchy

### DIFF
--- a/Plugins/Character2D/Source/Character2DRuntime/Public/Character2DActor.h
+++ b/Plugins/Character2D/Source/Character2DRuntime/Public/Character2DActor.h
@@ -201,6 +201,9 @@ private:
     void SetupSpriteComponent(UPaperSpriteComponent* Component, const FCharacter2DSpriteLayer& Layer);
     void SetupSkeletalComponent(USkeletalMeshComponent* Component, const FCharacter2DSkeletalPart& Part);
     void AttachSpriteToSocket(UPaperSpriteComponent* SpriteComp, const FCharacter2DSpriteLayer& Layer);
+    void AttachFlipbookToSocket(UPaperFlipbookComponent* FlipbookComp,
+        ECharacter2DAttachmentTarget Target, FName Socket, bool bUseSocketTransform,
+        const FVector& Offset, float Scale);
 
     bool HasValidSprites() const;
     bool HasValidSkeletalMeshes() const;

--- a/Plugins/Character2D/Source/Character2DRuntime/Public/Character2DAsset.h
+++ b/Plugins/Character2D/Source/Character2DRuntime/Public/Character2DAsset.h
@@ -89,6 +89,18 @@ struct FCharacter2DBlinkSettings
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Blink")
     float Scale = 1.0f;
 
+    /** Target skeletal mesh for attachment */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Blink|Attachment")
+    ECharacter2DAttachmentTarget AttachmentTarget = ECharacter2DAttachmentTarget::None;
+
+    /** Socket name on target skeletal mesh */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Blink|Attachment", meta=(EditCondition="AttachmentTarget != ECharacter2DAttachmentTarget::None", EditConditionHides))
+    FName SocketName;
+
+    /** Use socket transform or apply custom offset/scale */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Blink|Attachment", meta=(EditCondition="AttachmentTarget != ECharacter2DAttachmentTarget::None", EditConditionHides))
+    bool bUseSocketTransform = true;
+
     /** Мин/Макс интервал до моргания (сек) */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Blink", meta=(ClampMin="0.1"))
     float BlinkIntervalMin = 2.f;
@@ -121,6 +133,18 @@ struct FCharacter2DTalkSettings
     /** Локальный Scale */
     UPROPERTY(EditAnywhere, BlueprintReadOnly, Category="Talk")
     float Scale = 1.0f;
+
+    /** Target skeletal mesh for attachment */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Talk|Attachment")
+    ECharacter2DAttachmentTarget AttachmentTarget = ECharacter2DAttachmentTarget::None;
+
+    /** Socket name on target skeletal mesh */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Talk|Attachment", meta=(EditCondition="AttachmentTarget != ECharacter2DAttachmentTarget::None", EditConditionHides))
+    FName SocketName;
+
+    /** Use socket transform or apply custom offset/scale */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Talk|Attachment", meta=(EditCondition="AttachmentTarget != ECharacter2DAttachmentTarget::None", EditConditionHides))
+    bool bUseSocketTransform = true;
 
     /** Скорость зацикленного воспроизведения разговора */
     UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Talk", meta=(ClampMin="0.1"))


### PR DESCRIPTION
## Summary
- make head the parent for face sprite components
- attach face sprites to head socket if no target is specified
- attach flipbook components to head
- allow flipbook animations to specify skeletal socket attachments

## Testing
- `echo "No tests"`


------
https://chatgpt.com/codex/tasks/task_e_68435fa837e483269fe1f85d12390b4c