### PR TITLE
Organize sprite details cleanly

### DIFF
--- a/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/FCharacter2DAssetEditorToolkit.cpp
+++ b/Plugins/Character2D/Source/Character2DEditor/Private/Character2DAssetEditorToolkit/FCharacter2DAssetEditorToolkit.cpp
@@ -9,6 +9,7 @@
 #include "Data/Character2DPosePreset.h"
 #include "IDetailsView.h"
 #include "PropertyCustomizationHelpers.h"
+#include "DetailLayoutBuilder.h"
 
 #define LOCTEXT_NAMESPACE "Character2DAssetEditor"
 
@@ -17,6 +18,57 @@ const FName FCharacter2DAssetEditorToolkit::SkeletalDetailsTabID(TEXT("Character
 const FName FCharacter2DAssetEditorToolkit::SpriteDetailsTabID(TEXT("Character2DAssetEditor_SpriteDetails"));
 const FName FCharacter2DAssetEditorToolkit::ActionsTabID(TEXT("Character2DAssetEditor_Actions"));
 const FName FCharacter2DAssetEditorToolkit::PresetsTabID(TEXT("Character2DAssetEditor_Presets"));
+
+/* ====================================================================== */
+/*                         Sprite Details Customization                   */
+/* ====================================================================== */
+
+TSharedRef<IDetailCustomization> FCharacter2DSpriteCustomization::MakeInstance()
+{
+    return MakeShared<FCharacter2DSpriteCustomization>();
+}
+
+void FCharacter2DSpriteCustomization::CustomizeDetails(IDetailLayoutBuilder& DetailBuilder)
+{
+    TArray<TWeakObjectPtr<UObject>> Objects;
+    DetailBuilder.GetObjectsBeingCustomized(Objects);
+
+    UCharacter2DAsset* Asset = nullptr;
+    if (Objects.Num() == 1)
+    {
+        Asset = Cast<UCharacter2DAsset>(Objects[0]);
+    }
+
+    /* 1 ── СКРЫВАЕМ лишние категории раз и навсегда */
+    DetailBuilder.HideCategory(TEXT("Skeletal"));
+    DetailBuilder.HideCategory(TEXT("Sprite"));
+
+    /* 2 ── СКРЫВАЕМ корневые скелетные поля */
+    DetailBuilder.HideProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, Body));
+    DetailBuilder.HideProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, Arms));
+    DetailBuilder.HideProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, Head));
+
+    IDetailCategoryBuilder& CatBody  = DetailBuilder.EditCategory(TEXT("Sprite Body"));
+    IDetailCategoryBuilder& CatArms  = DetailBuilder.EditCategory(TEXT("Sprite Arms"));
+    IDetailCategoryBuilder& CatHead  = DetailBuilder.EditCategory(TEXT("Sprite Head"));
+    IDetailCategoryBuilder& CatTrans = DetailBuilder.EditCategory(TEXT("Sprite Transform"));
+
+    CatBody.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Body)));
+
+    CatArms.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Arms)));
+
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Head)));
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Eyebrow)));
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Eyes)));
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Eyelids)));
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.Mouth)));
+
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.EyelidsBlinkSettings)));
+    CatHead.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.MouthTalkSettings)));
+
+    CatTrans.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.GlobalOffset)));
+    CatTrans.AddProperty(DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(UCharacter2DAsset, SpriteStructure.GlobalScale)));
+}
 
 void FCharacter2DAssetEditorToolkit::InitEditor(EToolkitMode::Type Mode,
                                                 const TSharedPtr<IToolkitHost>& Host,
@@ -175,7 +227,8 @@ void FCharacter2DAssetEditorToolkit::InitEditor(EToolkitMode::Type Mode,
 				FSlateIcon());
 		}));
 
-	AddToolbarExtender(ToolbarExtender);
+        AddToolbarExtender(ToolbarExtender);
+
 }
 
 void FCharacter2DAssetEditorToolkit::RegisterTabSpawners(const TSharedRef<FTabManager>& InTabManager)
@@ -265,13 +318,16 @@ TSharedRef<SDockTab> FCharacter2DAssetEditorToolkit::SpawnSkeletalDetailsTab(con
 
 TSharedRef<SDockTab> FCharacter2DAssetEditorToolkit::SpawnSpriteDetailsTab(const FSpawnTabArgs& Args)
 {
-	SpriteDetailsView = CreateSpriteDetailsView();
-	
-	return SNew(SDockTab)
-		.Label(LOCTEXT("SpriteDetailsLabel", "Sprites"))
-		[
-			SpriteDetailsView.ToSharedRef()
-		];
+        SpriteDetailsView = CreateSpriteDetailsView();
+        SpriteDetailsView->RegisterInstancedCustomPropertyLayout(
+            UCharacter2DAsset::StaticClass(),
+            FOnGetDetailCustomizationInstance::CreateStatic(&FCharacter2DSpriteCustomization::MakeInstance));
+
+        return SNew(SDockTab)
+                .Label(LOCTEXT("SpriteDetailsLabel", "Sprites"))
+                [
+                        SpriteDetailsView.ToSharedRef()
+                ];
 }
 
 TSharedRef<SDockTab> FCharacter2DAssetEditorToolkit::SpawnActionsTab(const FSpawnTabArgs& Args)
@@ -434,27 +490,7 @@ TSharedRef<IDetailsView> FCharacter2DAssetEditorToolkit::CreateSpriteDetailsView
 	// Создаём само представление
 	TSharedRef<IDetailsView> DetailsView = PropertyEditorModule.CreateDetailView(DetailsViewArgs);
 
-	// Устанавливаем делегат видимости свойств:
-	// показываем теперь строго только свойства из категорий Sprite, Blink и Talk
-	DetailsView->SetIsPropertyVisibleDelegate(
-		FIsPropertyVisible::CreateLambda([](const FPropertyAndParent& PropertyAndParent) -> bool
-		{
-			const FProperty* Property = &PropertyAndParent.Property;
-			const FString PropertyName = Property->GetName();
-			const FString CategoryName = Property->GetMetaData(TEXT("Category"));
 
-			// Показываем свойства, относящиеся к Sprite (слои, Blink, Talk)
-			if (CategoryName.Contains(TEXT("Sprite")) ||
-				CategoryName.Contains(TEXT("Blink")) ||
-				CategoryName.Contains(TEXT("Talk")))
-			{
-				return true;
-			}
-
-			// Всё остальное скрываем
-			return false;
-		})
-	);
 
 	// Привязываем представление к текущему Asset’у и подписываемся на событие изменения
 	DetailsView->SetObject(AssetBeingEdited);
@@ -507,7 +543,7 @@ FLinearColor FCharacter2DAssetEditorToolkit::GetWorldCentricTabColorScale() cons
 
 void FCharacter2DAssetEditorToolkit::AddReferencedObjects(FReferenceCollector& Collector)
 {
-	// TObjectPtr automatically handles reference collection
+        // TObjectPtr automatically handles reference collection
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Plugins/Character2D/Source/Character2DEditor/Public/Character2DAssetEditorToolkit/FCharacter2DAssetEditorToolkit.h
+++ b/Plugins/Character2D/Source/Character2DEditor/Public/Character2DAssetEditorToolkit/FCharacter2DAssetEditorToolkit.h
@@ -8,14 +8,23 @@
 #include "Character2DEnums.h"
 #include "Slate/SCharacter2DPresetPanel.h"
 #include "Widgets/Docking/SDockTab.h"
+#include "IDetailCustomization.h"
 
 class SCharacter2DAssetViewport;
 class SCharacter2DActionPanel;
 
+class FCharacter2DSpriteCustomization : public IDetailCustomization
+{
+public:
+    static TSharedRef<IDetailCustomization> MakeInstance();
+
+    virtual void CustomizeDetails(IDetailLayoutBuilder& DetailBuilder) override;
+};
+
 class FCharacter2DAssetEditorToolkit : public FAssetEditorToolkit, public FGCObject
 {
 public:
-	void InitEditor(const EToolkitMode::Type Mode, const TSharedPtr<IToolkitHost>& InitToolkitHost, UCharacter2DAsset* InAsset);
+        void InitEditor(const EToolkitMode::Type Mode, const TSharedPtr<IToolkitHost>& InitToolkitHost, UCharacter2DAsset* InAsset);
 
 	virtual FName GetToolkitFName() const override;
 	virtual FText GetBaseToolkitName() const override;


### PR DESCRIPTION
## Summary
- hide Sprite and Skeletal categories while exposing custom sprite categories
- register sprite property customization only on the Sprite tab
- remove global customization registration and destructor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684855395348832699f52d1a60a6df18